### PR TITLE
Add cluster-local-gateway-service-account as needing anyuid

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,6 +115,7 @@ oc adm policy add-scc-to-user anyuid -z istio-mixer-post-install-account -n isti
 oc adm policy add-scc-to-user anyuid -z istio-mixer-service-account -n istio-system
 oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-system
 oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z cluster-local-gateway-service-account -n istio-system
 oc adm policy add-cluster-role-to-user cluster-admin -z istio-galley-service-account -n istio-system
 
 # Deploy Istio


### PR DESCRIPTION
As Istio latest release, cluster-local-gateway-service-account is a new service account for running cluster-local-gateway. Add it to the list.